### PR TITLE
Fixed empty CMAKE_OSX_SYSROOT issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,9 @@ set(GMP_MINIMAL_VERSION "6.0.0")
 set(NTL_MINIMAL_VERSION "11.0.0")
 
 # The -isysroot flag needs set.
-if (APPLE OR (CMAKE_CXX_PLATFORM_ID STREQUAL "Darwin"))
+if ((APPLE OR (CMAKE_CXX_PLATFORM_ID STREQUAL "Darwin")) AND
+    # This addresses the problem when CMAKE_OSX_SYSROOT is "" (e.g. when /usr/include/sys/types.h exists)
+    NOT CMAKE_OSX_SYSROOT STREQUAL "")
   set(macos_isysroot_flag "-isysroot ${CMAKE_OSX_SYSROOT}")
 else()
   set(macos_isysroot_flag "")


### PR DESCRIPTION
Fixed issue happening when CMAKE_OSX_SYSROOT is empty.
This happens when:
 - CMAKE_GENERATOR is not Xcode, 
 - CMAKE_OSX_DEPLOYMENT_TARGET is not set, 
 - CMAKE_OSX_ARCHITECTURES does not match "[^;]"
 - /usr/include/sys/types.h does not exist
That is the case on MacOS version previous to Mojave or when /usr/include/sys/types.h exists.
