### PR TITLE
Map to01speedup

### DIFF
--- a/src/eqtesting.cpp
+++ b/src/eqtesting.cpp
@@ -40,13 +40,20 @@ void mapTo01(const EncryptedArray& ea, Ctxt& ctxt)
 
   if (p > 2)
     ctxt.power(p - 1); // set y = x^{p-1}
-
+  long e = 1;
   long d = ea.getDegree();
-  if (d > 1) { // compute the product of the d automorphisms
-    std::vector<Ctxt> v(d, ctxt);
-    for (long i = 1; i < d; i++)
-      v[i].frobeniusAutomorph(i);
-    totalProduct(ctxt, v);
+  long b = NTL::NumBits(d);
+  Ctxt orig = ctxt;
+  for(long i = b - 2; i >= 0; i--){
+    Ctxt tmp = ctxt;
+    tmp.frobeniusAutomorph(e);
+    ctxt *= tmp;
+    e *= 2;
+    if(NTL::bit(d,i)){
+      ctxt.frobeniusAutomorph(1);
+      ctxt *= orig;
+       e+= 1;
+    }
   }
 }
 

--- a/src/eqtesting.cpp
+++ b/src/eqtesting.cpp
@@ -29,11 +29,10 @@ namespace helib {
 // and then outputting y * y^p * ... * y^{p^{d-1}}, with exponentiation to
 // powers of p done via Frobenius.
 
-// FIXME: the computation of the "norm" y * y^p * ... * y^{p^{d-1}}
-// can be done using O(log d) automorphisms, rather than O(d).
-
 void mapTo01(const EncryptedArray& ea, Ctxt& ctxt)
 {
+// Compute of the "norm" y * y^p * ... * y^{p^{d-1}}
+//  using O(log d) automorphisms, rather than O(d).
   long p = ctxt.getPtxtSpace();
   if (p != ea.getPAlgebra().getP()) // ptxt space is p^r for r>1
     throw LogicError("mapTo01 not implemented for r>1");


### PR DESCRIPTION
Optimize the function which maps only non zero elements to 1, and zero elements to 0, by implementing an alternative algorithm which takes O(logd) Frobenius automorphisms rather than O(d).