### PR TITLE
Refactor PSI IO to read from a stream

### DIFF
--- a/misc/psi/io/io.h
+++ b/misc/psi/io/io.h
@@ -73,7 +73,9 @@ helib::Database<TXT> readDbFromStream(StreamDispenser& databaseStreamDispenser,
     }
   } else { // Ctxt query
     NTL_EXEC_RANGE(nrow * ncol, first, last)
-    Reader<TXT> threadReader(reader.value());
+    // Create new reader for each thread
+    auto databaseStreamThreadPtr = databaseStreamDispenser.get();
+    Reader<TXT> threadReader(databaseStreamThreadPtr, zero_txt);
     for (long i = first; i < last; ++i) {
       long row = i / ncol;
       long col = i % ncol;
@@ -124,7 +126,9 @@ helib::Matrix<TXT> readQueryFromStream(StreamDispenser& queryStreamDispenser,
   } else { // Ctxt query
     // Read in ctxts
     NTL_EXEC_RANGE(nrow * ncol, first, last)
-    Reader<TXT> threadReader(reader.value());
+    // Create new reader for each thread
+    auto queryStreamThreadPtr = queryStreamDispenser.get();
+    Reader<TXT> threadReader(queryStreamThreadPtr, zero_txt);
     for (long i = first; i < last; ++i) {
       long row = i / ncol;
       long col = i % ncol;

--- a/misc/psi/io/io.h
+++ b/misc/psi/io/io.h
@@ -38,7 +38,7 @@ using sharedContext = std::shared_ptr<helib::Context>;
 using Ptxt = helib::Ptxt<helib::BGV>;
 
 template <typename TXT, typename StreamDispenser>
-helib::Database<TXT> readDbFromStream(StreamDispenser& databaseStreamDispenser,
+helib::Database<TXT> readDbFromStream(const StreamDispenser& databaseStreamDispenser,
                                       const sharedContext& contextp,
                                       const helib::PubKey& pk)
 {
@@ -88,7 +88,7 @@ helib::Database<TXT> readDbFromStream(StreamDispenser& databaseStreamDispenser,
 }
 
 template <typename TXT, typename StreamDispenser>
-helib::Matrix<TXT> readQueryFromStream(StreamDispenser& queryStreamDispenser,
+helib::Matrix<TXT> readQueryFromStream(const StreamDispenser& queryStreamDispenser,
                                        const helib::PubKey& pk)
 {
   auto queryStreamPtr = queryStreamDispenser.get();

--- a/misc/psi/io/stream_dispenser.h
+++ b/misc/psi/io/stream_dispenser.h
@@ -1,0 +1,20 @@
+template<typename Stream, typename... Args>
+class StreamDispenser {
+ private:
+  std::tuple<Args...> args;
+
+ public:
+  StreamDispenser(Args... args): args(std::make_tuple(args...)) {}
+
+  std::unique_ptr<Stream> get() const {
+    return std::apply([](const Args... args){
+        return std::make_unique<Stream>(args...);
+      }, args);
+  }
+};
+
+template<typename Stream, typename... Args>
+inline auto make_stream_dispenser(Args... args) {
+  return StreamDispenser<Stream, Args...>(args...);
+}
+

--- a/misc/psi/io/stream_dispenser.h
+++ b/misc/psi/io/stream_dispenser.h
@@ -1,3 +1,14 @@
+/* Copyright (C) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef STREAM_DISPENSER_H_
+#define STREAM_DISPENSER_H_
+
+#include<functional>
+#include<tuple>
+#include<memory>
+
 template<typename Stream, typename... Args>
 class StreamDispenser {
  private:
@@ -18,3 +29,4 @@ inline auto make_stream_dispenser(Args... args) {
   return StreamDispenser<Stream, Args...>(args...);
 }
 
+#endif // STREAM_DISPENSER_H_

--- a/utils/common/stream_dispenser.h
+++ b/utils/common/stream_dispenser.h
@@ -9,6 +9,9 @@
 #include<tuple>
 #include<memory>
 
+// Do not use this class directly. Create instances using the
+// make_stream_dispenser function
+// eg. make_stream_dispenser<std::ifstream>("filename", std::ios::binary)
 template<typename Stream, typename... Args>
 class StreamDispenser {
  private:


### PR DESCRIPTION
* Refactoring of PSI IO to be able to read directly from streams rather than only from files.
* Introduction of StreamDispenser class for "copying" streams by creating new instances of them and distributing a unique pointer to said stream.
* Old functionality still available.